### PR TITLE
Reconfigure header info during collapseAdats()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -84,6 +84,14 @@
 
 ### Updates and Improvements :hammer:
 
+* `collapseAdats()` better combines `HEADER` information (#86)
+  - certain information, e.g. `PlateScale` and `Cal*`,
+    are better maintained in the final collapsed ADAT
+  - other entries are combined by pasting into a single string
+  - should result in less duplication of superfluous entries and 
+    retention of more "useful" `HEADER` information
+    in the resulting (collapsed) `soma_adat`
+
 * Update `read_annotations()` with `11k` content (#85)
 
 * Update `transform()` and `scaleAnalytes()`

--- a/man/loadAdatsAsList.Rd
+++ b/man/loadAdatsAsList.Rd
@@ -69,7 +69,7 @@ class(collapsed)
 
 # Alternatively use `collapse = TRUE`
 \donttest{
-loadAdatsAsList(files, collapse = TRUE)
+  loadAdatsAsList(files, collapse = TRUE)
 }
 }
 \seealso{

--- a/tests/testthat/_snaps/loadAdatsAsList.md
+++ b/tests/testthat/_snaps/loadAdatsAsList.md
@@ -51,7 +51,7 @@
       [1] "!AssayVersion"
       
       $AssayRobot
-      [1] "Fluent 1 L-307"
+      [1] "Fluent 1 L-307, Fluent 1 L-307"
       attr(,"raw_key")
       [1] "!AssayRobot"
       
@@ -66,7 +66,7 @@
       [1] "!CreatedBy"
       
       $CreatedDate
-      [1] "2020-07-24"
+      [1] "2020-07-24, 2020-07-25"
       attr(,"raw_key")
       [1] "!CreatedDate"
       
@@ -121,7 +121,7 @@
       [1] "!StudyOrganism"
       
       $Title
-      [1] "Example Adat Set001, Example Adat Set002"
+      [1] "Example Adat Set001, Example Adat Set002, Example Adat Set001, Example Adat Set002"
       attr(,"raw_key")
       [1] "!Title"
       
@@ -215,64 +215,7 @@
       attr(,"raw_key")
       [1] "PlateTailTest_Example_Adat_Set002"
       
-      $AdatId
-      [1] "GID-1234-56-7890-abcdef"
-      attr(,"raw_key")
-      [1] "!AdatId"
-      
-      $Version
-      [1] "1.2"
-      attr(,"raw_key")
-      [1] "!Version"
-      
-      $AssayType
-      [1] "PharmaServices"
-      attr(,"raw_key")
-      [1] "!AssayType"
-      
-      $AssayVersion
-      [1] "V4"
-      attr(,"raw_key")
-      [1] "!AssayVersion"
-      
-      $AssayRobot
-      [1] "Fluent 1 L-307"
-      attr(,"raw_key")
-      [1] "!AssayRobot"
-      
-      $Legal
-      [1] "Experiment details and data have been processed to protect Personally Identifiable Information (PII) and comply with existing privacy laws."
-      attr(,"raw_key")
-      [1] "!Legal"
-      
-      $CreatedBy
-      [1] "PharmaServices"
-      attr(,"raw_key")
-      [1] "!CreatedBy"
-      
-      $CreatedDate
-      [1] "2020-07-25"
-      attr(,"raw_key")
-      [1] "!CreatedDate"
-      
-      $EnteredBy
-      [1] "Technician2"
-      attr(,"raw_key")
-      [1] "!EnteredBy"
-      
-      $GeneratedBy
-      [1] "Px (Build:  : ), Canopy_0.1.1"
-      attr(,"raw_key")
-      [1] "!GeneratedBy"
-      
-      $StudyMatrix
-      [1] "EDTA Plasma"
-      attr(,"raw_key")
-      [1] "!StudyMatrix"
-      
-      $Title
-      [1] "Example Adat Set001, Example Adat Set002"
-      attr(,"raw_key")
-      [1] "!Title"
+      $CollapsedAdats
+      [1] "example_data10.adat, single_sample.adat"
       
 


### PR DESCRIPTION
## Overview

- `collapseAdats()` now does a better job of maintaining useful information when combining ADATs during the collapse
  - PlateScale* and Cal* information is now merged, rather than concatenated, resulting in shorter set of attributes
  - new values in downstream ADATs are maintained, and no longer lost when written
- the majority of `HEADER` information is still that of the first, initial ADAT in the list
- the `stopifnot()` call gets more clear error message
- @wschwarzmann 
