### PR TITLE
Increase test coverage for pivotExpressionSet()

### DIFF
--- a/tests/testthat/test-pivotExpressionSet.R
+++ b/tests/testthat/test-pivotExpressionSet.R
@@ -4,10 +4,19 @@ sub_adat <- example_data[1:10, c(1:5, 35:37)]
 long     <- pivotExpressionSet(adat2eSet(sub_adat))
 
 # Testing ----
-test_that("pivotExpressionSet() returns the correct dimensions", {
+test_that("pivotExpressionSet() returns the correct class and dimensions", {
   expect_s3_class(long, "tbl_df")
   expect_equal(dim(long), c(30, 29))
+})
+
+test_that("pivotExpressionSet() returns expected metadata columns", {
   expect_setequal(rownames(sub_adat), long$array_id)
   expect_setequal(getAnalytes(sub_adat), long$feature)
-  skip("Add increased coverage unit tests for `pivotExpressionSet()`; issue #6")
+  expect_true(all(names(attributes(sub_adat)$Col.Meta) %in% names(long)))
+  expect_true(all(getMeta(sub_adat) %in% names(long)))
+})
+
+test_that("pivotExpressionSet() preserves analyte values", {
+  expect_equal(sub_adat[order(row.names(sub_adat)),]$seq.10000.28,
+               subset(long, feature == "seq.10000.28")$value)
 })


### PR DESCRIPTION
## Overview of Pull Request

- Adds additional tests for `pivotExpressionSet()` returning expected metadata columns and analyte values

Fixes #6 