### PR TITLE
Clean up example docs for parseHeader()

### DIFF
--- a/R/parseHeader.R
+++ b/R/parseHeader.R
@@ -19,7 +19,15 @@
 #' f <- system.file("extdata", "example_data10.adat",
 #'                  package = "SomaDataIO", mustWork = TRUE)
 #' header <- parseHeader(f)
-#' header
+#' names(header)
+#'
+#' header$Header.Meta
+#'
+#' header$file_specs
+#'
+#' header$row_meta
+#'
+#' head(as.data.frame(header$Col.Meta))
 #' @importFrom stats setNames
 #' @importFrom tibble enframe
 #' @export

--- a/man/parseHeader.Rd
+++ b/man/parseHeader.Rd
@@ -28,7 +28,15 @@ Parses the header section of an ADAT file.
 f <- system.file("extdata", "example_data10.adat",
                  package = "SomaDataIO", mustWork = TRUE)
 header <- parseHeader(f)
-header
+names(header)
+
+header$Header.Meta
+
+header$file_specs
+
+header$row_meta
+
+head(as.data.frame(header$Col.Meta))
 }
 \seealso{
 Other IO: 


### PR DESCRIPTION
## Overview of Pull Request

- modified example for parseHeader() to print list elements separately, rather than full object, which slowed website rendering

Fixes #115