### PR TITLE
Update macOS version in pkgdown.yaml

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -15,7 +15,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: macOS-12   # macOS important Bootstrap/bslib themes
+    runs-on: macOS-14   # macOS important Bootstrap/bslib themes
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- macOS-12 environment is deprecated in pkgdown github action workflow
- updated to macOS-14
