### PR TITLE
Relax annotations file version requirement

### DIFF
--- a/R/read-annotations.R
+++ b/R/read-annotations.R
@@ -34,26 +34,27 @@ read_annotations <- function(file) {
     )
   }
 
-  # do not recognize version
-  if ( !ver %in% names(ver_dict) ) {
-    stop(
-      "Unknown version of the annotations file: ", .value(ver), ".",
-      call. = FALSE
-    )
-  }
+  # check if recognized version
+  if ( ver %in% names(ver_dict) ) {
+    md5_file <- strtrim(md5sum(file), 7L) |> unname()
+    md5_true <- strtrim(ver_dict[[ver]]$sha, 7L)
 
-  md5_file <- strtrim(md5sum(file), 7L) |> unname()
-  md5_true <- strtrim(ver_dict[[ver]]$sha, 7L)
-
-  # file modified
-  if ( !identical(md5_file, md5_true) ) {
+    # file modified
+    if ( !identical(md5_file, md5_true) ) {
+      warning(
+        "Checksum mismatch. ", basename(file), " may have been modified.",
+        call. = FALSE
+      )
+    }
+    skip <- ver_dict[[ver]]$skip
+  } else {
     warning(
-      "Checksum mismatch. ", .value(basename(file)), " may have been modified.",
+      "Unknown version of the annotations file: ", ver, ".",
       call. = FALSE
     )
+    skip <- 8L
   }
 
-  skip <- ver_dict[[ver]]$skip
   tbl  <- readxl::read_xlsx(file, sheet = "Annotations", skip = skip)
 
   # map these fields to match those in ADATs

--- a/tests/testthat/test-read-annotations.R
+++ b/tests/testthat/test-read-annotations.R
@@ -26,14 +26,14 @@ test_that("`read_annotations()` parses the annotations file correctly", {
   expect_true(ver_dict[[ver]]$col_plasma == names(tbl)[ver_dict[[ver]]$which_plasma])
 })
 
-test_that("error conditions trigger stops when appropriate", {
+test_that("error conditions trigger stop and warnings when appropriate", {
 
   expect_error(
     read_annotations("foo.txt"),
     "Annotations file must be either"
   )
 
-  expect_error(
+  expect_warning(
     with_pkg_object(SomaDataIO:::ver_dict[-2L], read_annotations(file)),
     "Unknown version of the annotations file:"
   )
@@ -43,6 +43,6 @@ test_that("error conditions trigger stops when appropriate", {
   tmp$`SL-12345678-rev0-2021-01`$sha <- "x0x0x0x0x"
   expect_warning(
     with_pkg_object(tmp, read_annotations(file)),
-    "Checksum mismatch. 'test-anno.xlsx' may have been modified"
+    "Checksum mismatch. test-anno.xlsx may have been modified"
   )
 })


### PR DESCRIPTION
- return warning instead of error if annotations excel file version does not match specific values
