### PR TITLE
Updates to median normalization functionality

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,14 +3,21 @@
 ### New Functions
 
 * Added `medianNormalize()` function
-  - performs median normalization on `soma_adat` objects that have been 
-    hybridization normalized and plate scaled
+  - performs median normalization of study samples on `soma_adat` objects
+    that have been hybridization normalized and plate scaled
   - includes validation to ensure required normalization steps have been applied
   - supports multiple reference approaches:
     - Internal reference built from study samples
     - Reference extracted from existing `soma_adat` object
     - External reference as a data.frame
   - supports custom grouping by multiple clinical variables
+  
+* Added `reverseMedianNormalize()` function
+  - reverses median normalization (including ANML) that was previously
+    applied to study samples (`SampleType == "Sample"`)
+  - designed to work with standard SomaScan deliverable ADAT files where
+    study samples have undergone median or ANML normalization as the final
+    sample processing step
 
 ### Function and Object Improvements
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# SomaDataIO (6.5.0.9000)
+# SomaDataIO 6.5.0.9000
 
 ### New Functions
 
@@ -22,7 +22,7 @@
   - removed `getAnnoVer()` function and `ver_dict` object
   - removed `tools::md5sum` import dependency
 
-# SomaDataIO (6.5.0)
+# SomaDataIO 6.5.0
 
 ### Function and Object Improvements
 
@@ -48,7 +48,7 @@
 * Updated `dplyr` verb tests to no longer explicitly test
   for ordering of attributes (#165)
   
-# SomaDataIO (6.4.0)
+# SomaDataIO 6.4.0
 
 ### New Functions
 

--- a/R/medianNormalize.R
+++ b/R/medianNormalize.R
@@ -1,4 +1,4 @@
-#' Perform Median Normalization
+#' Perform Median Normalization on Study Samples
 #'
 #' @description Performs median normalization on a `soma_adat` object that has
 #' already undergone standard data processing for array-based SomaScan studies.
@@ -84,9 +84,9 @@
 #'   }
 #' @param by Character vector. Grouping variable(s) for grouped median
 #'   normalization. Must be column name(s) in the ADAT. Normalization will be
-#'   performed within each group separately. Default is `"SampleType"`. Note
-#'   that only study samples (SampleType == 'Sample') are normalized; QC,
-#'   Calibrator, and Buffer samples are automatically excluded.
+#'   performed within each group separately. Default is `NULL` (all samples
+#'   normalized together). Note that only study samples (SampleType == 'Sample')
+#'   are normalized; QC, Calibrator, and Buffer samples are automatically excluded.
 #' @param verbose Logical. Should progress messages be printed? Default is `TRUE`.
 #' @return A `soma_adat` object with median normalization applied and RFU values
 #'   adjusted. The existing `NormScale_*` columns are updated to include the
@@ -96,7 +96,7 @@
 #' # Starting with unnormalized ADAT
 #' unnormalized_adat <- read_adat("unnormalized_study_data.adat")
 #'
-#' # Internal reference from study samples (default)
+#' # Internal reference from study samples (default - all samples normalized together)
 #' med_norm_adat <- medianNormalize(unnormalized_adat)
 #'
 #' # Reference from another ADAT
@@ -107,9 +107,10 @@
 #' ref_data <- read.csv("reference_file.csv")
 #' med_norm_adat <- medianNormalize(unnormalized_adat, reference = ref_data)
 #'
-#' # Custom grouping by multiple variables
-#' # Use when total protein load changes due to analysis conditions
-#' med_norm_adat <- medianNormalize(unnormalized_adat, by = c("Sex", "SampleType"))
+#' # Custom grouping by biological variables
+#' # Use when samples should be normalized separately by group
+#' med_norm_adat <- medianNormalize(unnormalized_adat, by = "Sex")
+#' med_norm_adat <- medianNormalize(unnormalized_adat, by = c("Sex", "Age_Group"))
 #'
 #' # If you already have normalized data, first reverse the normalization
 #' normalized_adat <- read_adat("normalized_study_data.adat")
@@ -121,7 +122,7 @@
 #' @export
 medianNormalize <- function(adat,
                             reference = NULL,
-                            by = "SampleType",
+                            by = NULL,
                             verbose = TRUE) {
 
   # Input validation ----

--- a/R/reverseMedianNormalize.R
+++ b/R/reverseMedianNormalize.R
@@ -94,7 +94,7 @@ reverseMedianNormalize <- function(adat, verbose = TRUE) {
 
   # Determine which normalization type was applied to study samples ----
   # Only one type should be applied, check which was last
-  # Identify the last normalization-related token and ensure it is the final step
+  # Find the last step that contains "SMP" (sample transformation step)
   norm_idx <- which(
     grepl("MedNormSMP", step_tokens, ignore.case = TRUE) |
       grepl("anmlSMP", step_tokens, ignore.case = TRUE)
@@ -105,10 +105,17 @@ reverseMedianNormalize <- function(adat, verbose = TRUE) {
       call. = FALSE
     )
   }
+  
+  # Find the last step that contains "SMP" (indicating sample transformation)
+  smp_idx <- which(grepl("SMP", step_tokens, ignore.case = TRUE))
+  last_smp_idx <- if (length(smp_idx) > 0) smp_idx[length(smp_idx)] else 0
+  
   last_norm_idx <- norm_idx[length(norm_idx)]
-  if (last_norm_idx != length(step_tokens)) {
+  
+  # Check that the normalization step is the last SMP transformation step
+  if (last_norm_idx != last_smp_idx) {
     stop(
-      "Median/ANML normalization of study samples is not the final processing step. ",
+      "Median/ANML normalization of study samples is not the final SMP transformation step. ",
       "ProcessSteps: ", process_steps, ". ",
       "Reversal requires normalization to be the last transformation applied to study samples.",
       call. = FALSE

--- a/man/medianNormalize.Rd
+++ b/man/medianNormalize.Rd
@@ -2,9 +2,9 @@
 % Please edit documentation in R/medianNormalize.R
 \name{medianNormalize}
 \alias{medianNormalize}
-\title{Perform Median Normalization}
+\title{Perform Median Normalization on Study Samples}
 \usage{
-medianNormalize(adat, reference = NULL, by = "SampleType", verbose = TRUE)
+medianNormalize(adat, reference = NULL, by = NULL, verbose = TRUE)
 }
 \arguments{
 \item{adat}{A \code{soma_adat} object created using \code{\link[=read_adat]{read_adat()}}, containing
@@ -29,9 +29,9 @@ for each SeqId.}
 
 \item{by}{Character vector. Grouping variable(s) for grouped median
 normalization. Must be column name(s) in the ADAT. Normalization will be
-performed within each group separately. Default is \code{"SampleType"}. Note
-that only study samples (SampleType == 'Sample') are normalized; QC,
-Calibrator, and Buffer samples are automatically excluded.}
+performed within each group separately. Default is \code{NULL} (all samples
+normalized together). Note that only study samples (SampleType == 'Sample')
+are normalized; QC, Calibrator, and Buffer samples are automatically excluded.}
 
 \item{verbose}{Logical. Should progress messages be printed? Default is \code{TRUE}.}
 }
@@ -114,7 +114,7 @@ have already undergone median normalization (ANML or standard), first use
 # Starting with unnormalized ADAT
 unnormalized_adat <- read_adat("unnormalized_study_data.adat")
 
-# Internal reference from study samples (default)
+# Internal reference from study samples (default - all samples normalized together)
 med_norm_adat <- medianNormalize(unnormalized_adat)
 
 # Reference from another ADAT
@@ -125,9 +125,10 @@ med_norm_adat <- medianNormalize(unnormalized_adat, reference = ref_adat)
 ref_data <- read.csv("reference_file.csv")
 med_norm_adat <- medianNormalize(unnormalized_adat, reference = ref_data)
 
-# Custom grouping by multiple variables
-# Use when total protein load changes due to analysis conditions
-med_norm_adat <- medianNormalize(unnormalized_adat, by = c("Sex", "SampleType"))
+# Custom grouping by biological variables
+# Use when samples should be normalized separately by group
+med_norm_adat <- medianNormalize(unnormalized_adat, by = "Sex")
+med_norm_adat <- medianNormalize(unnormalized_adat, by = c("Sex", "Age_Group"))
 
 # If you already have normalized data, first reverse the normalization
 normalized_adat <- read_adat("normalized_study_data.adat")

--- a/tests/testthat/test-medianNormalize.R
+++ b/tests/testthat/test-medianNormalize.R
@@ -277,6 +277,26 @@ test_that("`medianNormalize` produces expected verbose output", {
   )
 })
 
+test_that("`medianNormalize` default behavior with by = NULL", {
+  # Test that the new default (by = NULL) works correctly
+  expect_no_error(
+    result_default <- medianNormalize(test_data, verbose = FALSE)
+  )
+
+  # Test that explicitly setting by = NULL gives the same result
+  expect_no_error(
+    result_explicit <- medianNormalize(test_data, by = NULL, verbose = FALSE)
+  )
+
+  # Both should produce identical results
+  expect_equal(result_default, result_explicit)
+
+  # Check that all samples are treated as one group (no grouping)
+  expect_true(is.soma_adat(result_default))
+  norm_cols <- grep("^NormScale_", names(result_default), value = TRUE)
+  expect_equal(length(norm_cols), 3)  # Should have 3 dilution groups
+})
+
 test_that("`medianNormalize` errors on already normalized data", {
   # Create ANML-like test data by modifying test_data
   anml_test_data <- test_data

--- a/tests/testthat/test-reverseMedianNormalize.R
+++ b/tests/testthat/test-reverseMedianNormalize.R
@@ -83,17 +83,46 @@ test_that("`reverseMedianNormalize` + `medianNormalize` workflow", {
   expect_true(grepl("MedNormSMP", final_header$ProcessSteps))
 })
 
-test_that("`reverseMedianNormalize` validates normalization is final step", {
-  # Test error when normalization is not the final step
+test_that("`reverseMedianNormalize` validates normalization is final SMP step", {
+  # Test error when normalization is not the final SMP transformation step
   test_data_invalid <- test_data_full
   header_meta <- attr(test_data_invalid, "Header.Meta")
-  header_meta$HEADER$ProcessSteps <- "Raw RFU, Hyb Normalization, medNormInt, anmlSMP, plateScale"  # anmlSMP not final
+  header_meta$HEADER$ProcessSteps <- "Raw RFU, Hyb Normalization, anmlSMP, medNormInt, CustomSMP"  # anmlSMP not final SMP step
   attr(test_data_invalid, "Header.Meta") <- header_meta
 
   expect_error(
     reverseMedianNormalize(test_data_invalid, verbose = FALSE),
-    "Median/ANML normalization of study samples is not the final processing step"
+    "Median/ANML normalization of study samples is not the final SMP transformation step"
   )
+})
+
+test_that("`reverseMedianNormalize` works with production ADATs having Filtered step", {
+  # Test that function works when "Filtered" step is appended after normalization
+  filtered_data <- test_data_full
+  header_meta <- attr(filtered_data, "Header.Meta")
+  header_meta$HEADER$ProcessSteps <- "Raw RFU, Hyb Normalization, medNormInt, plateScale, anmlSMP, Filtered"
+  attr(filtered_data, "Header.Meta") <- header_meta
+
+  # Add normalization scale factors
+  filtered_data$NormScale_20 <- c(1.15, 0.95, 1.08)
+  filtered_data$NormScale_0_5 <- c(1.22, 0.88, 1.12)
+  filtered_data$NormScale_0_005 <- c(0.93, 1.07, 0.98)
+
+  # Should not error despite "Filtered" being the final step
+  expect_no_error(
+    result <- reverseMedianNormalize(filtered_data, verbose = FALSE)
+  )
+
+  # Check that result is valid and normalization was reversed
+  expect_true(is.soma_adat(result))
+  result_header <- attr(result, "Header.Meta")$HEADER
+  expect_true(grepl("rev-anmlSMP", result_header$ProcessSteps))
+  
+  # Scale factors should be reset to 1.0 for study samples
+  sample_mask <- result$SampleType == "Sample"
+  expect_true(all(result$NormScale_20[sample_mask] == 1.0))
+  expect_true(all(result$NormScale_0_5[sample_mask] == 1.0))
+  expect_true(all(result$NormScale_0_005[sample_mask] == 1.0))
 })
 
 test_that("`reverseMedianNormalize` handles ANMLFractionUsed columns properly", {


### PR DESCRIPTION
- Updated `medianNormalize()` default `by` argument to `NULL`
  - changed default `by` parameter from "SampleType" to NULL
  - previous default of "SampleType" was confusing since the function only
    normalizes `SampleType == "Sample"`, so was not performing by
    group without modifying the `by` parameter

- Handle ADATs with Filtered ProcessStep in `reverseMedianNormalize()`
  - updated validation to check last sample transformation step
    before reversing normalization instead of absolute last step
  - added test case for ProcessSteps ending with non "SMP" sample
    transformation step