### PR TITLE
Re-order vignette articles

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -97,22 +97,29 @@ articles:
   - title: Loading and Wrangling
     navbar: ~
     contents:
-    - starts_with("articles/tips-")
+    - articles/tips-loading-and-wrangling
 
-  - title: Command Line Merge Tool
+  - title: Pre-Processing
     navbar: ~
     contents:
-    - articles/cli-merge-tool
+    - articles/pre-processing
 
   - title: Lifting and Bridging
     navbar: ~
     contents:
     - articles/lifting-and-bridging
 
-  - title: Pre-Processing
+  - title: Command Line Merge Tool
     navbar: ~
     contents:
-    - articles/pre-processing
+    - articles/cli-merge-tool
+
+  - title: Miscellaneous Tips
+    navbar: ~
+    contents:
+    - articles/tips-safely-map-values
+    - articles/tips-safely-rename-df
+    - articles/tips-train-test-setup
 
   - title: Statistical Workflow Examples
     contents:

--- a/vignettes/articles/pre-processing.Rmd
+++ b/vignettes/articles/pre-processing.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Pre-Processing SomaScan"
-author: "SomaScan Bioinformatics Team, Standard BioTools, Inc."
+author: "SomaScan Bioinformatics Team, SomaLogic Operating Co., Inc."
 description: >
   A primer on pre-processing 'SomaScan' data for analysis, including filtering
   samples and features, data QC, and transformations.

--- a/vignettes/articles/stat-three-group-analysis-anova.Rmd
+++ b/vignettes/articles/stat-three-group-analysis-anova.Rmd
@@ -110,7 +110,9 @@ using `dplyr`, `purrr`, and `stats::aov()`
 aov_tbl <- aov_tbl |>
   mutate(
     formula   = map(AptName, ~ as.formula(paste(.x, "~ Group"))), # create formula
-    aov_model = map(formula, ~ stats::aov(.x, data = cleanData)),  # fit ANOVA-models
+    aov_model = map(formula, ~ stats::aov(.x,                 # fit ANOVA-models
+                                          data = cleanData,   
+                                          contrasts = NULL)),  
     aov_smry  = map(aov_model, summary) |> map(1L),      # summary() method
     F.stat    = map(aov_smry, "F value") |> map_dbl(1L), # pull out F-statistic
     p.value   = map(aov_smry, "Pr(>F)") |> map_dbl(1L),  # pull out p-values


### PR DESCRIPTION
- adjusted the order of the listed vignette articles to align with typical workflow and most commonly used references
- added contrasts = NULL to aov() call in the ANOVA workflow article to denote the ability to modify and add contrasts to analysis if needed
