### PR TITLE
Remove addition of AptName to Col.Meta from `medianNormalize()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: SomaDataIO
 Title: Input/Output 'SomaScan' Data
-Version: 6.6.0
+Version: 6.6.0.9000
 Authors@R: c(
     person(given = "Stu",
            family = "Field",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# SomaDataIO 6.6.0.9000
+
+### Function and Object Improvements
+
+* Fixed bug in `medianNormalize()` related to addition of `AptName` column
+  in returned `Col.Meta` attribute
+  - internal `.addMedNormReference()` now updates `Col.Meta` directly 
+    rather than using `getAnalyteInfo()`, which returns an `AptName` column;
+    this avoids duplication in downstream function calls to `getAnalyteInfo()`
+
 # SomaDataIO 6.6.0
 
 ### New Functions

--- a/R/medianNormalize.R
+++ b/R/medianNormalize.R
@@ -824,8 +824,13 @@ medianNormalize <- function(adat,
 #' @noRd
 .addMedNormReference <- function(adat, ref_data, dil_groups) {
 
-  # Get analyte info
-  apt_data <- getAnalyteInfo(adat)
+  # Get analyte metadata directly
+  apt_data <- attr(adat, "Col.Meta")
+  analyte_info <- getAnalyteInfo(adat)
+
+  if (is.null(apt_data)) {
+    return(adat)  # No Col.Meta to update
+  }
 
   # Initialize the column if it doesn't exist
   if (!"medNormSMP_ReferenceRFU" %in% names(apt_data)) {
@@ -836,7 +841,8 @@ medianNormalize <- function(adat,
   if (!is.null(ref_data)) {
     for (dil_name in names(dil_groups)) {
       if (dil_name %in% names(ref_data)) {
-        dil_apts <- intersect(dil_groups[[dil_name]], getAnalytes(adat))
+        # Get aptamer names in this dilution group
+        dil_apts <- dil_groups[[dil_name]]
 
         if (length(dil_apts) > 0) {
           ref_values <- ref_data[[dil_name]]
@@ -845,27 +851,24 @@ medianNormalize <- function(adat,
           if (is.numeric(ref_values) && length(ref_values) == 1) {
             # Single reference value for the whole dilution group (round to 2 decimal places)
             rounded_value <- round(ref_values, 2)
-            apt_data$medNormSMP_ReferenceRFU[apt_data$AptName %in% dil_apts] <- rounded_value
+            # Update rows where AptName matches dilution aptamers
+            apt_data$medNormSMP_ReferenceRFU[analyte_info$AptName %in% dil_apts] <- rounded_value
           } else if (is.numeric(ref_values) && length(ref_values) > 1) {
             # Aptamer-specific reference values (round to 2 decimal places)
             for (apt in dil_apts) {
               if (apt %in% names(ref_values)) {
                 rounded_value <- round(ref_values[apt], 2)
-                apt_data$medNormSMP_ReferenceRFU[apt_data$AptName == apt] <- rounded_value
+                # Find row with matching AptName and update
+                apt_data$medNormSMP_ReferenceRFU[analyte_info$AptName == apt] <- rounded_value
               }
             }
           }
         }
       }
     }
-
-    # Update the analyte metadata
-    attr(adat, "Col.Meta") <- apt_data
   }
 
+  # Update the analyte metadata
+  attr(adat, "Col.Meta") <- apt_data
   invisible(adat)
 }
-
-
-
-

--- a/tests/testthat/test-medianNormalize.R
+++ b/tests/testthat/test-medianNormalize.R
@@ -72,6 +72,14 @@ test_that("`medianNormalize` Method 1: Internal reference (default)", {
   expect_true(grepl("MedNormSMP", result_header$ProcessSteps))
   expect_equal(result_header$NormalizationAlgorithm, "MedNorm")
   expect_true(grepl("intraplate, crossplate", result_header$MedNormReference))
+
+  # Check that Col.Meta does not have AptName column added
+  col_meta <- attr(result, "Col.Meta")
+  expect_false(any(c("AptName") %in% names(col_meta)))
+
+  # Check that analyte info does not have duplicate AptName columns
+  analyte_info <- getAnalyteInfo(result)
+  expect_false(any(c("AptName.x", "AptName.y") %in% names(analyte_info)))
 })
 
 test_that("`medianNormalize` Method 2: Reference from another ADAT", {


### PR DESCRIPTION
- fixed bug in `medianNormalize()` related to addition of `AptName` column in returned `Col.Meta` attribute
- internal `.addMedNormReference()` now updates `Col.Meta` directly rather than using `getAnalyteInfo()`, which returns an `AptName` column; this avoids duplication in downstream function calls to `getAnalyteInfo()`
